### PR TITLE
refactor: replace `cli-color` with `picocolors`

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/lib/persistant-job-queue.js
+++ b/lib/persistant-job-queue.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var clc = require('cli-color');
+var colors = require('picocolors');
 
 const moduleName = 'job-queue';
 const watt = require('gigawatts');
@@ -78,7 +78,7 @@ class PersistantJobQueue {
 
     /* FIXME: change dbg to info when it's no longer necessary */
     this.log.dbg(
-      `«${clc.blackBright.bold(this.name)}» waiting:${count} running:${
+      `«${colors.blackBright(colors.bold(this.name))}» waiting:${count} running:${
         this.running
       }`
     );

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   "author": "Mathieu Schroeter",
   "license": "MIT",
   "dependencies": {
-    "cli-color": "^1.2.0",
     "fs-extra": "^9.1.0",
     "gigawatts": "^4.0.1",
+    "picocolors": "^1.1.1",
     "xcraft-core-fs": "^2.0.0",
     "xcraft-core-log": "^2.1.1",
     "xcraft-core-utils": "^4.0.0"


### PR DESCRIPTION
`cli-color` -> `es5-ext` detected as a virus

https://github.com/medikoo/es5-ext/issues/186